### PR TITLE
revert: 지도/통계 API Redis 캐싱 복원 

### DIFF
--- a/BE/src/main/java/com/swkim/safetrip/SafetripApplication.java
+++ b/BE/src/main/java/com/swkim/safetrip/SafetripApplication.java
@@ -2,9 +2,11 @@ package com.swkim.safetrip;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableCaching
 @EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication

--- a/BE/src/main/java/com/swkim/safetrip/config/CacheWarmupRunner.java
+++ b/BE/src/main/java/com/swkim/safetrip/config/CacheWarmupRunner.java
@@ -1,0 +1,33 @@
+package com.swkim.safetrip.config;
+
+import com.swkim.safetrip.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("!test")
+@RequiredArgsConstructor
+public class CacheWarmupRunner implements ApplicationRunner {
+
+    private final ReportService reportService;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            log.info("캐시 warm-up 시작");
+            reportService.getCountryStatistics();
+            reportService.getStateStatistics();
+            reportService.getCityStatistics();
+            reportService.getScamActionStats();
+            reportService.getScamContextStats();
+            log.info("캐시 warm-up 완료");
+        } catch (Exception e) {
+            log.warn("캐시 warm-up 실패 - 서버는 정상 기동됩니다: {}", e.getMessage());
+        }
+    }
+}

--- a/BE/src/main/java/com/swkim/safetrip/config/RedisConfig.java
+++ b/BE/src/main/java/com/swkim/safetrip/config/RedisConfig.java
@@ -1,13 +1,24 @@
 package com.swkim.safetrip.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 public class RedisConfig {
@@ -35,5 +46,29 @@ public class RedisConfig {
         template.setValueSerializer(new StringRedisSerializer());
 
         return template;
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "spring.cache.type", havingValue = "redis", matchIfMissing = true)
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .activateDefaultTyping(
+                        BasicPolymorphicTypeValidator.builder()
+                                .allowIfBaseType(Object.class)
+                                .build(),
+                        ObjectMapper.DefaultTyping.EVERYTHING
+                );
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofHours(1))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(config)
+                .build();
     }
 }

--- a/BE/src/main/java/com/swkim/safetrip/service/ReportService.java
+++ b/BE/src/main/java/com/swkim/safetrip/service/ReportService.java
@@ -6,6 +6,7 @@ import com.swkim.safetrip.dto.response.ScamActionStatItem;
 import com.swkim.safetrip.repository.ReportJdbcRepository;
 import com.swkim.safetrip.repository.ReportNativeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,7 @@ public class ReportService {
     private final ReportNativeRepository reportNativeRepository;
     private final RiskLevelService riskLevelService;
 
+    @Cacheable(cacheNames = "scam-action-stats", key = "'global'")
     @Transactional(readOnly = true)
     public List<ScamActionStatItem> getScamActionStats() {
         return reportJdbcRepository.findScamActionStats();
@@ -31,6 +33,7 @@ public class ReportService {
         return reportJdbcRepository.findScamActionStatsByCountry(countryId);
     }
 
+    @Cacheable(cacheNames = "scam-context-stats", key = "'global'")
     @Transactional(readOnly = true)
     public List<ScamActionStatItem> getScamContextStats() {
         return reportJdbcRepository.findScamContextStats();
@@ -41,18 +44,21 @@ public class ReportService {
         return reportJdbcRepository.findScamContextStatsByCountry(countryId);
     }
 
+    @Cacheable(cacheNames = "map-countries", key = "'all'")
     @Transactional(readOnly = true)
     public RegionScamStatisticsResponse getCountryStatistics(){
         List<RegionScamStatisticsItem> items = reportJdbcRepository.findCountryStatistics();
         return new RegionScamStatisticsResponse(COUNTRY, riskLevelService.assignRiskLevels(items));
     }
 
+    @Cacheable(cacheNames = "map-states", key = "'all'")
     @Transactional(readOnly = true)
     public RegionScamStatisticsResponse getStateStatistics(){
         List<RegionScamStatisticsItem> items = reportJdbcRepository.findStateStatistics();
         return new RegionScamStatisticsResponse(STATE, riskLevelService.assignRiskLevels(items));
     }
 
+    @Cacheable(cacheNames = "map-cities", key = "'all'")
     @Transactional(readOnly = true)
     public RegionScamStatisticsResponse getCityStatistics(){
         List<RegionScamStatisticsItem> items = reportJdbcRepository.findCityStatistics();

--- a/BE/src/main/java/com/swkim/safetrip/service/UserReportService.java
+++ b/BE/src/main/java/com/swkim/safetrip/service/UserReportService.java
@@ -18,6 +18,8 @@ import com.swkim.safetrip.repository.UserCountryStatsRepository;
 import com.swkim.safetrip.repository.UserReportRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -43,6 +45,13 @@ public class UserReportService {
     private final UserReportRepository userReportRepository;
     private final UserCountryStatsRepository userCountryStatsRepository;
 
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "map-countries", allEntries = true),
+            @CacheEvict(cacheNames = "map-states", allEntries = true),
+            @CacheEvict(cacheNames = "map-cities", allEntries = true),
+            @CacheEvict(cacheNames = "scam-action-stats", allEntries = true),
+            @CacheEvict(cacheNames = "scam-context-stats", allEntries = true)
+    })
     @Transactional
     public Long saveUserReport(String email, UserReportSaveRequest userReportSaveRequest, List<MultipartFile> files) {
 
@@ -155,6 +164,13 @@ public class UserReportService {
                 .toList();
     }
 
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "map-countries", allEntries = true),
+            @CacheEvict(cacheNames = "map-states", allEntries = true),
+            @CacheEvict(cacheNames = "map-cities", allEntries = true),
+            @CacheEvict(cacheNames = "scam-action-stats", allEntries = true),
+            @CacheEvict(cacheNames = "scam-context-stats", allEntries = true)
+    })
     @Transactional
     public void updateUserReport(Long reportId, String email, UserReportUpdateRequest request, List<MultipartFile> images) {
         UserReport report = userReportRepository.findById(reportId)
@@ -216,6 +232,13 @@ public class UserReportService {
         log.info("User report updated: id={}, user={}", reportId, email);
     }
 
+    @Caching(evict = {
+            @CacheEvict(cacheNames = "map-countries", allEntries = true),
+            @CacheEvict(cacheNames = "map-states", allEntries = true),
+            @CacheEvict(cacheNames = "map-cities", allEntries = true),
+            @CacheEvict(cacheNames = "scam-action-stats", allEntries = true),
+            @CacheEvict(cacheNames = "scam-context-stats", allEntries = true)
+    })
     @Transactional
     public void deleteUserReport(Long reportId, String email) {
         UserReport report = userReportRepository.findById(reportId)

--- a/BE/src/test/resources/application-test.yml
+++ b/BE/src/test/resources/application-test.yml
@@ -16,6 +16,8 @@ spring:
   sql:
     init:
       mode: never  # schema.sql/data.sql 자동 실행 방지 (원하면 always로 변경)
+  cache:
+    type: none
   data:
     redis:
       host: localhost


### PR DESCRIPTION
집계 테이블로 단건 latency는 해결됐으나 stress(150VU)에서 DB CPU 100% 포화 확인. 읽기 위주·전역 동일 데이터인 지도/통계 API에 Redis 캐싱을
재도입해 DB 부하를 분산한다. #189(캐싱 제거) revert.

- ReportService: 전역 통계 5개 @Cacheable 복원 (map-countries/states/cities, scam-action/context-stats). 국가별/사이드바는 적중률 낮아 제외 유지
- UserReportService: save/update/delete @CacheEvict 복원 (즉시 무효화)
- RedisConfig: cacheManager 빈 복원 (RedisTemplate는 토큰/rate-limit용 유지)
- CacheWarmupRunner: 재생성 — 서버 기동 시 캐시 선적재로 콜드 스타트 제거 (blue-green 배포마다 재발하는 콜드 미스 스탬피드 방지)